### PR TITLE
docs: for issue #7, a list of all docs DRAFT 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Cosmos Advocates
 
 ## Docs list
 
-See the working [list of docs](../docs_list/) that provides links to the published documentation, the repo or repos, and describes the intended purpose of the content.
+See the working [list of docs](./docs_list/) that provides links to the published documentation, the repo or repos, and describes the intended purpose of the content.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # advocates
+
 Cosmos Advocates
+
+## Docs list
+
+See the working [list of docs](../docs_list/) that provides links to the published documentation, the repo or repos, and describes the intended purpose of the content.

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Cosmos Advocates
 
 ## Docs list
 
-See the working [list of docs](./docs_list/) that provides links to the published documentation, the repo or repos, and describes the intended purpose of the content.
+See the working [list of docs](./docs_list.md/) for the primary owners and links to the published documentation and the repo or repos.

--- a/docs_list.md
+++ b/docs_list.md
@@ -58,7 +58,25 @@ A working list of docs with links to the published documentation, the repo or re
 
     </details>
 
-  - [Cosmos SDK API docs](gRPC, REST, and Tendermint Endpoints) also in this repo
+## Cosmos SDK API Legacy REST and gRPC Gateway docs
+
+- Maintainers:
+
+- Tobias EcoDev verify base URL and supported versions 2x/year
+
+- <https://github.com/cosmos/cosmos-sdk/blob/master/docs/core/grpc_rest.md>
+
+- API docs for:
+
+  - Gaia REST
+
+  - Tendermint RPC
+
+  - Transactions
+
+  - Cosmos Queries
+
+  - and others
 
 ## Cosmos SDK Tutorials
 
@@ -68,19 +86,25 @@ A working list of docs with links to the published documentation, the repo or re
 
 - <https://github.com/cosmos/sdk-tutorials>
 
-- Tutorials for building modules for the Cosmos SDK. Links to videos.
+- Tutorials for building modules for the Cosmos SDK. Links to articles and videos.
 
-  <details><summary>Top-level contents WIP</summary>
+  <details><summary>Top-level contents</summary>
+
+    Stargate:
+
+    - IBC Hello World
+
+    - Blog for Starport
+
+    - Proof of File Existence Migration
+
+    Launchpad:
 
     - Voter
 
     - Blog
 
-    - Blog (legacy)
-
     - PoFE
-
-    - PoFE - Launchpad to Stargate
 
     - Scavenge
 
@@ -92,7 +116,7 @@ A working list of docs with links to the published documentation, the repo or re
 
 ## Starport docs
 
-- Maintainers: EcoDev Tobias/Barrie and DevX Denis
+- Maintainers: AIB EcoDev Barrie and DevX Denis
 
 - [github.com/tendermint/starport](https://github.com/tendermint/starport/tree/develop/docs)
 
@@ -104,17 +128,15 @@ A working list of docs with links to the published documentation, the repo or re
 
   <details><summary>Top-level contents WIP</summary>
 
-  - Introduction
+  - Introduction to Starport
 
-  - Install
+  - Run a Blockchain
 
-  - Quickstart
+  - Project Scaffold Reference
 
-  - Serving a blockchain
+  - Type Scaffold Reference
 
-  - Scaffolding
-
-  - Configuration
+  - Configure a Blockchain
 
   - Relayer
 
@@ -122,13 +144,13 @@ A working list of docs with links to the published documentation, the repo or re
 
 ## Tendermint Core
 
-- Maintainer: Tess GmbH
+- Maintainer: Interchain GmbH Tess
 
 - [docs.tendermint.com](https://docs.tendermint.com/master/)
 
 - <https://github.com/tendermint/tendermint/tree/master/docs>
 
-- Blockchain application platform, BFT state machine replication.
+- BFT Consensus Engine used by the Cosmos SDK and other blockchain applications.
 
   <details><summary>Top-level contents</summary>
 
@@ -148,6 +170,40 @@ A working list of docs with links to the published documentation, the repo or re
 
   - Spec
 
-  - security
+  - Security
 
   </details>
+
+## CosmJS documentation
+
+- Maintainer: Simon at Confio
+
+- <https://cosmos.github.io/cosmjs/>
+
+- Front end to build first app, missing examples
+
+## Relayers command list
+
+- Maintainer:
+
+- <https://github.com/cosmos/relayer/blob/master/docs/commands.md>
+
+- App that relays data between IBC-enabled chains.
+
+## Other community docs
+
+We won't track these other docs.
+
+- [Agoric](https://agoric.com/documentation/)
+
+- [Cosmos IBC Account Documentation](https://chainapsis.github.io/cosmos-sdk-interchain-account/)
+
+- [CosmWasm Documentation](https://docs.cosmwasm.com/)
+
+- [Ethermint Documentation](https://docs.ethermint.zone/)
+
+- [Haskell Cosmos SDK](http://kepler.dev/)
+
+- [Hermes Guide](https://hermes.informal.systems/)
+
+- [Lotion](https://lotionjs.com/introduction.html) unmaintained

--- a/docs_list.md
+++ b/docs_list.md
@@ -4,11 +4,11 @@ A working list of docs with links to the published documentation, the repo or re
 
 ## Cosmos Hub
 
-- [Cosmos Hub](https://hub.cosmos.network/main/hub-overview/overview.html)
+- [hub.cosmos.network](https://hub.cosmos.network/main/hub-overview/overview.html)
 
 - <https://github.com/cosmos/gaia/tree/master/docs>
 
-- Using the Cosmos SDK application for the Cosmos Hub.
+- Using the Cosmos SDK application for the Cosmos Hub, called Gaia.
 
   <details><summary>Top-level contents</summary>
 
@@ -24,9 +24,9 @@ A working list of docs with links to the published documentation, the repo or re
 
 ## Cosmos SDK Documentation
 
-- [Cosmos SDK Documentation](https://docs.cosmos.network/) _why 2 repos?_
+- [docs.cosmos.network](https://docs.cosmos.network/)
 
-- <https://github.com/allinbits/cosmos-sdk/tree/master/docs>
+- <https://github.com/cosmos/cosmos-sdk/tree/master/docs>
 
 - <https://github.com/cosmos/cosmos-sdk/tree/master/docs> <!-- two repos, what is the difference? -->
 
@@ -58,7 +58,7 @@ A working list of docs with links to the published documentation, the repo or re
 
 ## Cosmos SDK Tutorials
 
-- [Cosmos SDK Tutorials](https://tutorials.cosmos.network/)
+- [tutorials.cosmos.network](https://tutorials.cosmos.network/)
 
 - <https://github.com/cosmos/sdk-tutorials>
 
@@ -86,7 +86,7 @@ A working list of docs with links to the published documentation, the repo or re
 
 ## Starport
 
-- [Tendermint Starport](https://github.com/tendermint/starport/tree/develop/docs)
+- [github.com/tendermint/starport](https://github.com/tendermint/starport/tree/develop/docs)
 
 - <https://github.com/tendermint/starport>
 
@@ -114,7 +114,7 @@ A working list of docs with links to the published documentation, the repo or re
 
 ## Tendermint Core
 
-- [Tendermint Core](https://docs.tendermint.com/master/)
+- [docs.tendermint.com](https://docs.tendermint.com/master/)
 
 - <https://github.com/tendermint/tendermint/tree/master/docs>
 

--- a/docs_list.md
+++ b/docs_list.md
@@ -4,6 +4,8 @@ A working list of docs with links to the published documentation, the repo or re
 
 ## Cosmos Hub
 
+- Maintainer: design team
+
 - [hub.cosmos.network](https://hub.cosmos.network/main/hub-overview/overview.html)
 
 - <https://github.com/cosmos/gaia/tree/master/docs>
@@ -24,10 +26,11 @@ A working list of docs with links to the published documentation, the repo or re
 
 ## Cosmos SDK Documentation
 
+- Maintainer: REGEN and Tendermint Inc
+
 - [docs.cosmos.network](https://docs.cosmos.network/)
 
 - <https://github.com/cosmos/cosmos-sdk/tree/master/docs>
-
 
 - Learn about open source Cosmos SDK framework.
 
@@ -55,7 +58,11 @@ A working list of docs with links to the published documentation, the repo or re
 
     </details>
 
+  - [Cosmos SDK API docs](gRPC, REST, and Tendermint Endpoints) also in this repo
+
 ## Cosmos SDK Tutorials
+
+- Maintainers: Tendermint AIB EcoDev Tobias
 
 - [tutorials.cosmos.network](https://tutorials.cosmos.network/)
 
@@ -63,7 +70,7 @@ A working list of docs with links to the published documentation, the repo or re
 
 - Tutorials for building modules for the Cosmos SDK. Links to videos.
 
-  <details><summary>Top-level contents</summary>
+  <details><summary>Top-level contents WIP</summary>
 
     - Voter
 
@@ -83,7 +90,9 @@ A working list of docs with links to the published documentation, the repo or re
 
   </details>
 
-## Starport
+## Starport docs
+
+- Maintainers: EcoDev Tobias/Barrie and DevX Denis
 
 - [github.com/tendermint/starport](https://github.com/tendermint/starport/tree/develop/docs)
 
@@ -93,7 +102,7 @@ A working list of docs with links to the published documentation, the repo or re
 
 - Note: View the docs only in the repo or the [gitpod workspace](https://gitpod.io/#https://github.com/tendermint/starport/tree/master).
 
-  <details><summary>Top-level contents</summary>
+  <details><summary>Top-level contents WIP</summary>
 
   - Introduction
 
@@ -112,6 +121,8 @@ A working list of docs with links to the published documentation, the repo or re
   </details>
 
 ## Tendermint Core
+
+- Maintainer: Tess GmbH
 
 - [docs.tendermint.com](https://docs.tendermint.com/master/)
 

--- a/docs_list.md
+++ b/docs_list.md
@@ -1,0 +1,143 @@
+# Docs list
+
+A working list of docs with links to the published documentation, the repo or repos, and the intended purpose of the technical content.
+
+## Cosmos Hub
+
+- [Cosmos Hub](https://hub.cosmos.network/main/hub-overview/overview.html)
+
+- <https://github.com/cosmos/gaia/tree/master/docs>
+
+- Using the Cosmos SDK application for the Cosmos Hub.
+
+  <details><summary>Top-level contents</summary>
+
+  - Cosmos Hub
+
+  - Delegators
+
+  - Gaia Tutorials
+
+  - Validators
+
+  </details>
+
+## Cosmos SDK Documentation
+
+- [Cosmos SDK Documentation](https://docs.cosmos.network/) _why 2 repos?_
+
+- <https://github.com/allinbits/cosmos-sdk/tree/master/docs>
+
+- <https://github.com/cosmos/cosmos-sdk/tree/master/docs> <!-- two repos, what is the difference? -->
+
+- Learn about open source Cosmos SDK framework.
+
+  <details><summary>Top-level contents</summary>
+
+    - Introduction
+
+    - Basics
+
+    - Core Concepts
+
+    - Building Modules
+
+    - IBC
+
+    - Running a Node, API and CLI
+
+    - Migrations
+
+    - USING THE SDK
+
+      - Modules
+
+        - List of Modules
+
+    </details>
+
+## Cosmos SDK Tutorials
+
+- [Cosmos SDK Tutorials](https://tutorials.cosmos.network/)
+
+- <https://github.com/cosmos/sdk-tutorials>
+
+- Tutorials for building modules for the Cosmos SDK. Links to videos.
+
+  <details><summary>Top-level contents</summary>
+
+    - Voter
+
+    - Blog
+
+    - Blog (legacy)
+
+    - PoFE
+
+    - PoFE - Launchpad to Stargate
+
+    - Scavenge
+
+    - Nameservice
+
+    - Cosmos Burner Chain
+
+  </details>
+
+## Starport
+
+- [Tendermint Starport](https://github.com/tendermint/starport/tree/develop/docs)
+
+- <https://github.com/tendermint/starport>
+
+- Tool to bootstrap blockchains. Developer-friendly, easiest way to build a blockchain.
+
+- Note: View the docs only in the repo or the [gitpod workspace](https://gitpod.io/#https://github.com/tendermint/starport/tree/master).
+
+  <details><summary>Top-level contents</summary>
+
+  - Introduction
+
+  - Install
+
+  - Quickstart
+
+  - Serving a blockchain
+
+  - Scaffolding
+
+  - Configuration
+
+  - Relayer
+
+  </details>
+
+## Tendermint Core
+
+- [Tendermint Core](https://docs.tendermint.com/master/)
+
+- <https://github.com/tendermint/tendermint/tree/master/docs>
+
+- Blockchain application platform, BFT state machine replication.
+
+  <details><summary>Top-level contents</summary>
+
+  - Introduction
+
+  - Guides
+
+  - Apps
+
+  - Nodes
+
+  - Tendermint Core
+
+  - Networks
+
+  - Tooling
+
+  - Spec
+
+  - security
+
+  </details>

--- a/docs_list.md
+++ b/docs_list.md
@@ -28,7 +28,6 @@ A working list of docs with links to the published documentation, the repo or re
 
 - <https://github.com/cosmos/cosmos-sdk/tree/master/docs>
 
-- <https://github.com/cosmos/cosmos-sdk/tree/master/docs> <!-- two repos, what is the difference? -->
 
 - Learn about open source Cosmos SDK framework.
 


### PR DESCRIPTION
a first draft and shorter-than-expected list of all docs for https://github.com/cosmos/advocates/issues/7 

I added a collapsed details section with a high-level table of contents since I needed reminding of what lived in the docs, see [the docs_list Markdown file](https://github.com/cosmos/advocates/blob/7-list-all-docs/docs_list.md ) to enjoy this summary. 
![image](https://user-images.githubusercontent.com/10067215/109724727-fe268d80-7b7d-11eb-8712-0d244395f0bd.png)


Open questions:
- what else do we need? 
- where do the API docs live?

I'm open to feedback. 